### PR TITLE
add leading slack to shipment URLs

### DIFF
--- a/lib/finale/shipment_item.rb
+++ b/lib/finale/shipment_item.rb
@@ -14,7 +14,7 @@ module Finale
     def format_for_post(account)
       {
         productUrl: resource_path(:product, account: account, id: @product_id),
-        facilityUrl: resource_path(:facility, account: account, id: @facility_id),
+        facilityUrl: resource_path(:facility, account: account, id: @facility_id, leading_slash: true),
         quantity: @quantity,
         lotId: @lot_id&.rjust(12, 'L_') # L_F0137A3-U0
       }.compact

--- a/lib/finale/uri_helper.rb
+++ b/lib/finale/uri_helper.rb
@@ -11,8 +11,10 @@ module Finale
       "#{url_base}/#{resource_path}"
     end
 
-    def resource_path(resource, account: @account, id: nil, action: nil)
-      [account, 'api', resource, id, action].compact.join('/')
+    def resource_path(resource, account: @account, id: nil, action: nil, leading_slash: false)
+      path = [account, 'api', resource, id, action].compact.join('/')
+      path = leading_slash ? "/#{path}" : path
+      path
     end
   end
 end

--- a/lib/finale/version.rb
+++ b/lib/finale/version.rb
@@ -1,3 +1,3 @@
 module Finale
-  VERSION = '0.2.1'
+  VERSION = '0.2.3'
 end

--- a/spec/finale/shipment_item_spec.rb
+++ b/spec/finale/shipment_item_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Finale::ShipmentItem do
     let(:expected) {
       {
         productUrl: 'account/api/product/product_1',
-        facilityUrl: 'account/api/facility/facility_1',
+        facilityUrl: '/account/api/facility/facility_1',
         quantity: 1,
         lotId: 'L_F0AAAAA-U0'
       }
@@ -32,7 +32,7 @@ RSpec.describe Finale::ShipmentItem do
       let(:expected) {
         {
           productUrl: 'account/api/product/product_1',
-          facilityUrl: 'account/api/facility/facility_1',
+          facilityUrl: '/account/api/facility/facility_1',
           quantity: 1
         }
       }


### PR DESCRIPTION
Add leading slash for facility url only. Finale changed the validation on this url along with 2 others we don't use.

From Finale:
```
Finale Inventory has updated the validations for the shipment this week. We have added validations for:
  1. the shipment items' facilityUrl parameter
  2. the shipment's destinationFacilityUrl, and originFacilityUrl

Turns out the facilityUrl you're sending notion/api/facility/10031 is missing a / at the beginning, so it should be like /notion/api/facility/10031.
```